### PR TITLE
Fix for null reference exception when trying to vote

### DIFF
--- a/BeatSaverVoting/Plugin.cs
+++ b/BeatSaverVoting/Plugin.cs
@@ -63,7 +63,7 @@ namespace BeatSaverVoting
         }
 
         [Init]
-        public void Init(object thisIsNull, IPALogger pluginLogger)
+        public void Init(IPALogger pluginLogger)
         {
             Utilities.Logging.Log = pluginLogger;
         }

--- a/BeatSaverVoting/Plugin.cs
+++ b/BeatSaverVoting/Plugin.cs
@@ -62,10 +62,9 @@ namespace BeatSaverVoting
             UI.VotingUI.instance.Setup();
         }
 
-
+        [Init]
         public void Init(object thisIsNull, IPALogger pluginLogger)
         {
-
             Utilities.Logging.Log = pluginLogger;
         }
 


### PR DESCRIPTION
This adds the BSIPA4 attribute to make the init function work, so all the functions that use the logger don't throw null ref exceptions, most importantly the vote function.